### PR TITLE
Import dependencies for Validator

### DIFF
--- a/src/Rules/ArrayRules.php
+++ b/src/Rules/ArrayRules.php
@@ -3,6 +3,7 @@
 namespace NovaAttachMany\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
 
 class ArrayRules implements Rule
 {
@@ -31,7 +32,7 @@ class ArrayRules implements Rule
 
         $this->rules = [$attribute => $this->rules];
 
-        $validator = \Validator::make($input, $this->rules, $this->messages($attribute));
+        $validator = Validator::make($input, $this->rules, $this->messages($attribute));
 
         $this->message = $validator->errors()->get($attribute);
 


### PR DESCRIPTION
The current implementation does not import its dependencies and relies on the implementing application to have registered the Alias.