### PR TITLE
Find the correct relatable query filter methods

### DIFF
--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -41,9 +41,10 @@ class AttachController extends Controller
             ->where('attribute', $relationship)
             ->first();
 
-        $query = $field->resourceClass::newModel()->query();
+        $model = $field->resourceClass::newModel();
+        $query = $model->query();
 
-        return forward_static_call($this->associatableQueryCallable($request, $query), $request, $query, $field)->get()
+        return forward_static_call($this->associatableQueryCallable($request, $model), $request, $query, $field)->get()
             ->mapInto($field->resourceClass)
             ->filter(function ($resource) use ($request, $field) {
                 return $request->newResource()->authorizedToAttach($request, $resource->resource);


### PR DESCRIPTION
We're incorrectly passing a `Illuminate\Database\Eloquent\Builder` to `AttachController::associatableQueryCallback` instead of the relationship's model class, so we don't find any of the `relatable{Model}` dynamic methods defined on the resource.